### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Expand a path with the shell variables of form `$var` and `${var}`.
 
 #### `fileglob(pattern: str) → list[str]`
 
-Get all files in a filesystem subtree accoring to a glob pattern.
+Get all files in a filesystem subtree according to a glob pattern.
 
 **Example:**
 

--- a/src/jinja2_copier_extension/_filters/path.py
+++ b/src/jinja2_copier_extension/_filters/path.py
@@ -70,7 +70,7 @@ def do_expandvars(path: str) -> str:
 
 
 def do_fileglob(pattern: str) -> list[str]:
-    """Get all files in a filesystem subtree accoring to a glob pattern.
+    """Get all files in a filesystem subtree according to a glob pattern.
 
     Args:
         pattern: A glob pattern.

--- a/tests/filters/test_path.py
+++ b/tests/filters/test_path.py
@@ -53,7 +53,7 @@ def test_expandvars(env: Environment, var: str) -> None:
 
 
 def test_fileglob(env: Environment, tmp_path: Path) -> None:
-    """Test getting all files in a filesystem subtree accoring to a glob pattern."""
+    """Test getting all files in a filesystem subtree according to a glob pattern."""
     build_file_tree(
         {
             tmp_path / "a.txt": "",


### PR DESCRIPTION
I've fixed a typo

```diff
-accoring
+according
```

in docstrings and in the README.