### PR TITLE
chore(uv): configure installing all dependency groups with `default-groups = "all"`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ typing = [
 ]
 
 [tool.uv]
-default-groups = ["dev", "test", "typing"]
+required-version = ">=0.6.8"
+default-groups = "all"
 
 [tool.ruff]
 src = ["src"]


### PR DESCRIPTION
I've updated the `uv` settings to install all dependency groups via `default-groups = "all"`. The `"all"` value was introduced in `uv` [v0.6.8](https://github.com/astral-sh/uv/releases/tag/0.6.8), so I've also set the required minimum version accordingly.