### PR TITLE
chore(config): migrate pytest configuration to `[tool.pytest]` section in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,8 @@ convention = "google"
 implicit_reexport = true
 strict = true
 
-[tool.pytest.ini_options]
-addopts = "--cov --cov-report=term-missing"
+[tool.pytest]
+addopts = ["--cov", "--cov-report=term-missing"]
 
 [tool.coverage.run]
 source_pkgs = ["jinja2_copier_extension"]


### PR DESCRIPTION
Starting with pytest [v9.0.0](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05), native TOML configuration is supported including an idiomatic [`[tool.pytest]` section in `pyproject.toml`](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml). Since [we're already using pytest v9+](https://github.com/copier-org/jinja2-copier-extension/blob/e5f114c99f657bcffa7e76f7acacb3e3782a8a53/pyproject.toml#L43), I've migrated our pytest configuration accordingly. 